### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Linux X-Bows Driver
 
-[Quick start](docs/quick-start.md)
-[Configuration](docs/config.md)
-[Documentation](docs/api.md)
-[Specifications](docs/spec.md)
-[Status](docs/status.md)
+[Quick start](doc/quick-start.md)
+[Configuration](doc/config.md)
+[Documentation](doc/api.md)
+[Specifications](doc/spec.md)
+[Status](doc/status.md)


### PR DESCRIPTION
links pointing to `docs/` not `doc/`