### PR TITLE
Update quick-start.md

### DIFF
--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -15,6 +15,7 @@ work with 4.9 or newer but you'll have to set the std=c++11 flag.
 sudo apt-get install cmake g++ libyaml-cpp-dev
 sudo apt-get install autotools-dev autoconf automake libtool
 sudo apt-get install libudev-dev libusb-1.0-0-dev
+sudo apt-get install libboost-all-dev
 ```
 
 1. Obtain the source code


### PR DESCRIPTION
added additional requirement for the `#include <boost/algorithm/string.hpp>` in `src/driver_parse.cc` [source] - unsure if all systems require this? (I'm using ubuntu 19.10)

[source]:https://www.boost.org/doc/libs/1_72_0/boost/algorithm/string.hpp